### PR TITLE
Prepare release/1.64.10

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/cbajapan/acb-client-sdk.git",
         "state": {
           "branch": null,
-          "revision": "63d213aa561ed2222331ff73e5c4cee53dfa3c0a",
-          "version": "3.4.0"
+          "revision": "6a5e1563b7997e244461fc8c2d2a1d85fbd05b2d",
+          "version": "3.4.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,17 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 import PackageDescription
 
 let package = Package(
     name: "AssistSDK",
+    platforms: [ .iOS(.v12) ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "AssistSDK",
             type: .static,
             targets: ["LASDK"]),
     ],
     dependencies: [
-        .package(name: "ACBClientSDK", url: "https://github.com/cbajapan/acb-client-sdk.git", .exact("3.4.0"))
+        .package(name: "ACBClientSDK", url: "https://github.com/cbajapan/acb-client-sdk.git", .exact("3.4.3"))
     ],
     targets: [
         .target(
@@ -22,6 +20,6 @@ let package = Package(
                 "AssistSDK",
                 .product(name: "ACBClientSDK", package: "ACBClientSDK")
             ]),
-        .binaryTarget(name: "AssistSDK", url: "https://objc-sdk.s3.us-east-2.amazonaws.com/live_assist_sdk/assist_sdk/AssistSDK-1.64.8-rc.1.2.xcframework.zip", checksum: "c7dbf5aab1cd70d6f38bfc1f9d1bbcfa8279f01c145cceeb36fef32b597e1058")
+        .binaryTarget(name: "AssistSDK", url: "https://objc-sdk.s3.us-east-2.amazonaws.com/live_assist_sdk/assist_sdk/AssistSDK-1.64.10.xcframework.zip", checksum: "01622a291f573f5ef5d116b0cbb141802c568c1004a88f45478e56c3c3e9ba46")
     ]
 )


### PR DESCRIPTION
Updating SPM manifest for the `1.64.10` release. This targets the `3.4.3` release of FCSDK.

